### PR TITLE
fix error when onDemandPercentage: 0

### DIFF
--- a/src/ec2cluster.test.ts
+++ b/src/ec2cluster.test.ts
@@ -77,6 +77,23 @@ describe("ec2cluster", () => {
     )
   })
 
+  test("error when specifying a single instance type with onDemandPercentage: 0", () => {
+    const stack = new Stack()
+    const vpc = new Vpc(stack, "VPC")
+
+    expect(() => {
+      const ec2Cluster = new Ec2Cluster(stack, "Ec2Cluster", {
+        instanceTypes: ["t3.medium"],
+        onDemandPercentage: 0,
+        vpc,
+      })
+    }).toThrow(
+      new Error(
+        "When using spot instances, please set multiple instance types."
+      )
+    )
+  })
+
   test("error when specifying multiple instance types with on-demand", () => {
     const stack = new Stack()
     const vpc = new Vpc(stack, "VPC")

--- a/src/ec2cluster.ts
+++ b/src/ec2cluster.ts
@@ -90,7 +90,8 @@ export class Ec2Cluster extends Construct {
     })
 
     this.spot =
-      props.onDemandPercentage && props.onDemandPercentage !== 100
+      typeof props.onDemandPercentage !== "undefined" &&
+      props.onDemandPercentage! < 100
         ? true
         : false
 


### PR DESCRIPTION
Input:
```typescript
          const ec2Cluster = new Ec2Cluster(this, 'Cluster', {
            vpc,
            instanceTypes: ['t3.micro', 't2.micro'],
            desiredCapacity: 1,
            onDemandPercentage: 0,
          })
```

Bug:
```
$ npx cdk diff

When using on-demand instances, please set single instance type.
```