### PR TITLE
rename hostname

### DIFF
--- a/src/__snapshots__/ec2cluster.test.ts.snap
+++ b/src/__snapshots__/ec2cluster.test.ts.snap
@@ -505,7 +505,7 @@ host_name=",
                   Object {
                     "Ref": "Ec2Cluster796ACAF5",
                   },
-                  "-$(echo $instance_id)
+                  "--$(echo $instance_id)
 hostnamectl set-hostname $host_name
 aws ec2 create-tags --region ",
                   Object {
@@ -1607,7 +1607,7 @@ host_name=",
                   Object {
                     "Ref": "Ec2Cluster796ACAF5",
                   },
-                  "-$(echo $instance_id)
+                  "--$(echo $instance_id)
 hostnamectl set-hostname $host_name
 aws ec2 create-tags --region ",
                   Object {
@@ -2734,7 +2734,7 @@ host_name=",
                   Object {
                     "Ref": "Ec2Cluster796ACAF5",
                   },
-                  "-$(echo $instance_id)
+                  "--$(echo $instance_id)
 hostnamectl set-hostname $host_name
 aws ec2 create-tags --region ",
                   Object {
@@ -3836,7 +3836,7 @@ host_name=",
                   Object {
                     "Ref": "Ec2Cluster796ACAF5",
                   },
-                  "-$(echo $instance_id)
+                  "--$(echo $instance_id)
 hostnamectl set-hostname $host_name
 aws ec2 create-tags --region ",
                   Object {

--- a/src/ec2cluster.ts
+++ b/src/ec2cluster.ts
@@ -195,7 +195,7 @@ export class Ec2Cluster extends Construct {
         `yum install -y https://amazon-ssm-${Aws.region}.s3.amazonaws.com/latest/linux_amd64/amazon-ssm-agent.rpm`,
         "systemctl start amazon-ssm-agent",
         "instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)",
-        `host_name=${clusterName}-$(echo $instance_id)`,
+        `host_name=${clusterName}--$(echo $instance_id)`,
         "hostnamectl set-hostname $host_name",
         `aws ec2 create-tags --region ${Aws.region} --resources $instance_id --tags Key=Name,Value=$host_name`,
         "until metadata=$(curl -s --fail http://localhost:51678/v1/metadata); do sleep 1; done;",


### PR DESCRIPTION
Change the number of hyphens to 2 to make it easy to distinguish the cluster name and instance id

Before:
`cluster-name-i-xxxxxxxxxxxxxxxxx`

After
`cluster-name--i-xxxxxxxxxxxxxxxxx`