### PR TITLE
userData is now required in IMachineImage in aws-cdk >= 1.29.0

### DIFF
--- a/src/lib/imported-image.ts
+++ b/src/lib/imported-image.ts
@@ -2,6 +2,7 @@ import {
   IMachineImage,
   MachineImageConfig,
   OperatingSystemType,
+  UserData
 } from "@aws-cdk/aws-ec2"
 import { Construct } from "@aws-cdk/core"
 
@@ -11,6 +12,7 @@ export class ImportedImage implements IMachineImage {
     return {
       imageId: this.amiId,
       osType: OperatingSystemType.LINUX,
+      userData: UserData.forLinux(),
     }
   }
 }


### PR DESCRIPTION
ref: https://github.com/aws/aws-cdk/pull/6066

This change is necessary to bump aws-cdk to latest (v1.35.0), though it's safe to apply current master (with aws-cdk v1.28.0). According to upstream changes, pre-1.29 detects osType and sets proper userData, in this case `UserData.forLinux()`.
